### PR TITLE
CLI fixes

### DIFF
--- a/cli/cmd.js
+++ b/cli/cmd.js
@@ -18,7 +18,7 @@ program
     .version(JSON.parse(fs.readFileSync(path.join(__dirname, "..", "package.json"), "utf-8")).version)
     .option("-u, --username <username>", "User name")
     .option("-p, --password <password>", "Password")
-    .option("-T, --apitoken <apitoken>", "SSO API Token")
+    .option("-T, --apiToken <apitoken>", "SSO API Token")
     .option("-t, --tenant <tenant>", "Tenant name")
     .option("-r, --repository <url>", "Repository URL")
     .option("-j, --json", "Output as JSON")

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -2,6 +2,6 @@
 // Exports
 //
 
-exports.REPOSITORY_URL = "http://mpulse.soasta.com/concerto/services/rest/RepositoryService/v1";
+exports.REPOSITORY_URL = "https://mpulse.soasta.com/concerto/services/rest/RepositoryService/v1";
 exports.TIMELINE_URL = "http://localhost:8080/concerto";
 exports.ANNOTATION_URL = "http://localhost:8080/concerto";


### PR DESCRIPTION
Fixes two CLI issues:
* Failure when using the default Repository URL (omitting the `-r` param).
* Failure when using an API token instead of a password (`-T` param instead of `-p`).