### PR TITLE
Migrate transport formatter to winston 3.x and prevent argv override via commander

### DIFF
--- a/cli/cmd.js
+++ b/cli/cmd.js
@@ -10,39 +10,41 @@
  * @tutorial CommandLineExtending
  */
 
-var program = require("commander");
-var path = require("path");
-var fs = require("fs");
+exports.program = function() {
+    var program = require("commander");
+    var path = require("path");
+    var fs = require("fs");
 
-program
-    .version(JSON.parse(fs.readFileSync(path.join(__dirname, "..", "package.json"), "utf-8")).version)
-    .option("-u, --username <username>", "User name")
-    .option("-p, --password <password>", "Password")
-    .option("-T, --apiToken <apiToken>", "SSO API Token")
-    .option("-t, --tenant <tenant>", "Tenant name")
-    .option("-r, --repository <url>", "Repository URL")
-    .option("-j, --json", "Output as JSON")
-    .option("-o, --output <file>", "Output file")
-    .option("-v, --verbose", "Verbose debugging")
-    .option("-a, --auth <file>", "auth.json file containing credentials")
-    .option("-d, --details <boolean>", "Enable/Disable retrieving full object details")
-    .option("-i, --stdin", "Use STDIN if file is required");
+	program
+		.version(JSON.parse(fs.readFileSync(path.join(__dirname, "..", "package.json"), "utf-8")).version)
+		.option("-u, --username <username>", "User name")
+		.option("-p, --password <password>", "Password")
+		.option("-T, --apiToken <apiToken>", "SSO API Token")
+		.option("-t, --tenant <tenant>", "Tenant name")
+		.option("-r, --repository <url>", "Repository URL")
+		.option("-j, --json", "Output as JSON")
+		.option("-o, --output <file>", "Output file")
+		.option("-v, --verbose", "Verbose debugging")
+		.option("-a, --auth <file>", "auth.json file containing credentials")
+		.option("-d, --details <boolean>", "Enable/Disable retrieving full object details")
+		.option("-i, --stdin", "Use STDIN if file is required");
 
-// commands
-program.command("query <type> [<params>]")
-    .description("query for objects by type with optional parameters (comma separated)")
-    .action(require("./query.js"));
+	// commands
+	program.command("query <type> [<params>]")
+		.description("query for objects by type with optional parameters (comma separated)")
+		.action(require("./query.js"));
 
-program.command("delete <type> <id>")
-    .description("delete objects")
-    .action(require("./delete.js"));
+	program.command("delete <type> <id>")
+		.description("delete objects")
+		.action(require("./delete.js"));
 
-program.command("update <type> <id> [file]")
-    .description("Update an object in the repository based on the JSON formatted data in a file")
-    .action(require("./update.js"));
+	program.command("update <type> <id> [file]")
+		.description("Update an object in the repository based on the JSON formatted data in a file")
+		.action(require("./update.js"));
 
-program.command("create [file]")
-    .description("Create a new object based on the JSON data in <file>")
-    .action(require("./create.js"));
+	program.command("create [file]")
+		.description("Create a new object based on the JSON data in <file>")
+		.action(require("./create.js"));
 
-exports.program = program;
+	return program;
+}

--- a/cli/core.js
+++ b/cli/core.js
@@ -13,6 +13,7 @@
 //
 var fs = require("fs");
 var _ = require("lodash");
+var winston = require("winston");
 
 var log = require("../lib/util/log");
 var constants = require("../lib/constants");
@@ -31,10 +32,11 @@ exports.init = function(options) {
     var authJsonPath = "auth.json";
 
     if (options && options.parent && typeof options.parent.json === "undefined") {
-        log.transports.console.json =  false;
+        log.format = winston.format.cli();
     } else {
-        log.transports.console.json =  true;
+        log.format = winston.format.json();
     }
+
 
     if (options && options.parent && options.parent.verbose) {
         log.transports.console.level = "debug";

--- a/cliAnnotation/cmd.js
+++ b/cliAnnotation/cmd.js
@@ -9,67 +9,68 @@
  *
  * @tutorial CommandLineExtending
  */
+exports.program = function() {
+	var program = require("commander");
+	var path = require("path");
+	var fs = require("fs");
 
-var program = require("commander");
-var path = require("path");
-var fs = require("fs");
+	program
+		.version(JSON.parse(fs.readFileSync(path.join(__dirname, "..", "package.json"), "utf-8")).version)
+		.option("-u, --username <username>", "User name")
+		.option("-p, --password <password>", "Password")
+		.option("-T, --apiToken <apiToken>", "SSO API Token")
+		.option("-t, --tenant <tenant>", "Tenant name")
+		.option("-r, --repository <url>", "Repository URL")
+		.option("-j, --json", "Output as JSON")
+		.option("-o, --output <file>", "Output file")
+		.option("-v, --verbose", "Verbose debugging")
+		.option("-a, --auth <file>", "auth.json file containing credentials")
+		.option("-d, --details <boolean>", "Enable/Disable retrieving full object details")
+		.option("-i, --stdin", "Use STDIN if file is required");
 
-program
-    .version(JSON.parse(fs.readFileSync(path.join(__dirname, "..", "package.json"), "utf-8")).version)
-    .option("-u, --username <username>", "User name")
-    .option("-p, --password <password>", "Password")
-    .option("-T, --apiToken <apiToken>", "SSO API Token")
-    .option("-t, --tenant <tenant>", "Tenant name")
-    .option("-r, --repository <url>", "Repository URL")
-    .option("-j, --json", "Output as JSON")
-    .option("-o, --output <file>", "Output file")
-    .option("-v, --verbose", "Verbose debugging")
-    .option("-a, --auth <file>", "auth.json file containing credentials")
-    .option("-d, --details <boolean>", "Enable/Disable retrieving full object details")
-    .option("-i, --stdin", "Use STDIN if file is required");
+	program.on("--help", function() {
+		console.log("  \n  Generate test data parameters:");
+		console.log("");
+		console.log("    $ testdata-gen --help");
+		console.log("");
+	});
 
-program.on("--help", function() {
-    console.log("  \n  Generate test data parameters:");
-    console.log("");
-    console.log("    $ testdata-gen --help");
-    console.log("");
-});
+	program.parse(process.argv);
+	if (process.argv.indexOf("testdata-gen") > -1) {
+		console.log(" \n  Optional parameters (comma separated)\n");
+		console.log("   count          count=     <number>                  Number timeline objects to be created");
+		console.log("   domainIds      domainId=  <domain ids>              Domain id");
+		console.log("   start          start=     <11234564512121>          Annonation start time in miliseconds");
+		console.log("   end            end=       <11234564512121>          Annotation end time in milisecond");
+		console.log("   type           type=      <'USER_ENTERED', 'MP_ALERT', or 'DIMENSION_EXPLOSION'>" +
+					"          The type of annotation object you want to be created");
+		console.log(" \n");
+	}
 
-program.parse(process.argv);
-if (process.argv.indexOf("testdata-gen") > -1) {
-    console.log(" \n  Optional parameters (comma separated)\n");
-    console.log("   count          count=     <number>                  Number timeline objects to be created");
-    console.log("   domainIds      domainId=  <domain ids>              Domain id");
-    console.log("   start          start=     <11234564512121>          Annonation start time in miliseconds");
-    console.log("   end            end=       <11234564512121>          Annotation end time in milisecond");
-    console.log("   type           type=      <'USER_ENTERED', 'MP_ALERT', or 'DIMENSION_EXPLOSION'>" +
-        "          The type of annotation object you want to be created");
-    console.log(" \n");
+	// commands
+	program.command("query [<params>]")
+		.description("query of timeline objects with optional parameters (comma separated)")
+		.action(require("./query.js"));
+
+	program.command("delete <id>")
+		.description("delete objects")
+		.action(require("./delete.js"));
+
+	program.command("get <id>")
+		.description("get timeline object by id")
+		.action(require("./get.js"));
+
+	program.command("create [file]")
+		.description("Create a new annotation object based on the JSON data in <file>")
+		.action(require("./create.js"));
+
+	program.command("update <id> [file]")
+		.description("Update an annotation object in the repository based on the JSON formatted data in a file")
+		.action(require("./update.js"));
+
+	program.command("testdata [<params>]")
+		.description("Create a new object with optional parameters (comma separated)")
+		.action(require("./testdata.js"));
+
+	return program;
 }
-
-// commands
-program.command("query [<params>]")
-    .description("query of timeline objects with optional parameters (comma separated)")
-    .action(require("./query.js"));
-
-program.command("delete <id>")
-    .description("delete objects")
-    .action(require("./delete.js"));
-
-program.command("get <id>")
-    .description("get timeline object by id")
-    .action(require("./get.js"));
-
-program.command("create [file]")
-    .description("Create a new annotation object based on the JSON data in <file>")
-    .action(require("./create.js"));
-
-program.command("update <id> [file]")
-    .description("Update an annotation object in the repository based on the JSON formatted data in a file")
-    .action(require("./update.js"));
-
-program.command("testdata [<params>]")
-    .description("Create a new object with optional parameters (comma separated)")
-    .action(require("./testdata.js"));
-
-exports.program = program;

--- a/cliAnnotation/core.js
+++ b/cliAnnotation/core.js
@@ -13,6 +13,7 @@
 //
 var fs = require("fs");
 var _ = require("lodash");
+var winston = require("winston");
 
 var log = require("../lib/util/log");
 var constants = require("../lib/constants");
@@ -31,9 +32,9 @@ exports.init = function(options) {
     var authJsonPath = "auth.json";
 
     if (options && options.parent && typeof options.parent.json === "undefined") {
-        log.transports.console.json =  false;
+        log.format = winston.format.cli();
     } else {
-        log.transports.console.json =  true;
+        log.format = winston.format.json();
     }
 
     if (options && options.parent && options.parent.verbose) {

--- a/cliTimeline/cmd.js
+++ b/cliTimeline/cmd.js
@@ -9,67 +9,70 @@
  *
  * @tutorial CommandLineExtending
  */
+exports.program = function () {
+	var program = require("commander");
+	var path = require("path");
+	var fs = require("fs");
 
-var program = require("commander");
-var path = require("path");
-var fs = require("fs");
+	program
+		.version(JSON.parse(fs.readFileSync(path.join(__dirname, "..", "package.json"), "utf-8")).version)
+		.option("-u, --username <username>", "User name")
+		.option("-p, --password <password>", "Password")
+		.option("-T, --apiToken <apiToken>", "SSO API Token")
+		.option("-t, --tenant <tenant>", "Tenant name")
+		.option("-r, --repository <url>", "Repository URL")
+		.option("-j, --json", "Output as JSON")
+		.option("-o, --output <file>", "Output file")
+		.option("-v, --verbose", "Verbose debugging")
+		.option("-a, --auth <file>", "auth.json file containing credentials")
+		.option("-d, --details <boolean>", "Enable/Disable retrieving full object details")
+		.option("-i, --stdin", "Use STDIN if file is required");
 
-program
-    .version(JSON.parse(fs.readFileSync(path.join(__dirname, "..", "package.json"), "utf-8")).version)
-    .option("-u, --username <username>", "User name")
-    .option("-p, --password <password>", "Password")
-    .option("-T, --apiToken <apiToken>", "SSO API Token")
-    .option("-t, --tenant <tenant>", "Tenant name")
-    .option("-r, --repository <url>", "Repository URL")
-    .option("-j, --json", "Output as JSON")
-    .option("-o, --output <file>", "Output file")
-    .option("-v, --verbose", "Verbose debugging")
-    .option("-a, --auth <file>", "auth.json file containing credentials")
-    .option("-d, --details <boolean>", "Enable/Disable retrieving full object details")
-    .option("-i, --stdin", "Use STDIN if file is required");
+	program.on("--help", function() {
+		console.log("  \n  Generate test data parameters:");
+		console.log("");
+		console.log("    $ testdata-gen --help");
+		console.log("");
+	});
 
-program.on("--help", function() {
-    console.log("  \n  Generate test data parameters:");
-    console.log("");
-    console.log("    $ testdata-gen --help");
-    console.log("");
-});
+	program.parse(process.argv);
+	if (process.argv.indexOf("testdata-gen") > -1) {
+		console.log(" \n  Optional parameters (comma separated)\n");
+		console.log("   count          count=    <number>                  Number timeline objects to be created");
+		console.log("   appIds         appIds=   <app ids>                 App ids");
+		console.log("   start          start=    <11234564512121>          Event start time in miliseconds");
+		console.log("   end            end=      <11234564512121>          Event end time in milisecond");
+		console.log("   type           type=     <'Insights' or 'Badge'>          " +
+					"The type of timeline object you want to be created");
+		console.log(" \n");
+	}
 
-program.parse(process.argv);
-if (process.argv.indexOf("testdata-gen") > -1) {
-    console.log(" \n  Optional parameters (comma separated)\n");
-    console.log("   count          count=    <number>                  Number timeline objects to be created");
-    console.log("   appIds         appIds=   <app ids>                 App ids");
-    console.log("   start          start=    <11234564512121>          Event start time in miliseconds");
-    console.log("   end            end=      <11234564512121>          Event end time in milisecond");
-    console.log("   type           type=     <'Insights' or 'Badge'>          " +
-        "The type of timeline object you want to be created");
-    console.log(" \n");
+	// commands
+	program.command("query [<params>]")
+		.description("query of timeline objects with optional parameters (comma separated)")
+		.action(require("./query.js"));
+
+	program.command("delete <id>")
+		.description("delete objects")
+		.action(require("./delete.js"));
+
+	program.command("get <id>")
+		.description("get timeline object by id")
+		.action(require("./get.js"));
+
+	program.command("create [file]")
+		.description("Create a new timeline object based on the JSON data in <file>")
+		.action(require("./create.js"));
+
+	program.command("testdata [<params>]")
+		.description("Create a new object with optional parameters (comma separated)")
+		.action(require("./testdata.js"));
+
+	program.command("update <id> [file]")
+		.description("Update timeline object in the repository based on the JSON formatted data in a file")
+		.action(require("./update.js"));
+
+	program = program;
+
+	return program;
 }
-
-// commands
-program.command("query [<params>]")
-    .description("query of timeline objects with optional parameters (comma separated)")
-    .action(require("./query.js"));
-
-program.command("delete <id>")
-    .description("delete objects")
-    .action(require("./delete.js"));
-
-program.command("get <id>")
-    .description("get timeline object by id")
-    .action(require("./get.js"));
-
-program.command("create [file]")
-    .description("Create a new timeline object based on the JSON data in <file>")
-    .action(require("./create.js"));
-
-program.command("testdata [<params>]")
-    .description("Create a new object with optional parameters (comma separated)")
-    .action(require("./testdata.js"));
-
-program.command("update <id> [file]")
-    .description("Update timeline object in the repository based on the JSON formatted data in a file")
-    .action(require("./update.js"));
-
-exports.program = program;

--- a/cliTimeline/core.js
+++ b/cliTimeline/core.js
@@ -13,6 +13,7 @@
 //
 var fs = require("fs");
 var _ = require("lodash");
+var winston = require("winston");
 
 var log = require("../lib/util/log");
 var constants = require("../lib/constants");
@@ -31,9 +32,9 @@ exports.init = function(options) {
     var authJsonPath = "auth.json";
 
     if (options && options.parent && typeof options.parent.json === "undefined") {
-        log.transports.console.json =  false;
+        log.format = winston.format.cli();
     } else {
-        log.transports.console.json =  true;
+        log.format = winston.format.json();
     }
 
     if (options && options.parent && options.parent.verbose) {

--- a/cmd.js
+++ b/cmd.js
@@ -3,4 +3,4 @@ var program = require("./cli/cmd.js").program;
 var fs = require("fs");
 
 // go
-program.parse(process.argv);
+program().parse(process.argv);

--- a/cmdAnnotation.js
+++ b/cmdAnnotation.js
@@ -3,4 +3,4 @@ var program = require("./cliAnnotation/cmd.js").program;
 var fs = require("fs");
 
 // go
-program.parse(process.argv);
+program().parse(process.argv);

--- a/cmdTimeline.js
+++ b/cmdTimeline.js
@@ -3,4 +3,4 @@ var program = require("./cliTimeline/cmd.js").program;
 var fs = require("fs");
 
 // go
-program.parse(process.argv);
+program().parse(process.argv);

--- a/index.js
+++ b/index.js
@@ -18,8 +18,12 @@ if (typeof window === "undefined") {
     * @desc
     * Exports the [Repository CLI API client]{@link cmd} to access the CLI application
     * to interact from a shell with the Repository
+    *
+    * @example
+    * // Retrieve instance
+    * require('soasta-repository').cmd()
     */
-    exports.cmd = require("./cli/cmd").program;
+    exports.cmdRepository = require("./cli/cmd").program;
 
     /**
     * @export CLI
@@ -27,7 +31,7 @@ if (typeof window === "undefined") {
     * @desc
     * Exports the [CLI utility class]{@link CLI} to initialize the API for CLI use
     */
-    exports.CLI = require("./cli/core");
+    exports.CLIRepository = require("./cli/core");
 
     /**
      * @export cmdAnnotation
@@ -36,7 +40,7 @@ if (typeof window === "undefined") {
      * Exports the [Annotation CLI API client]{@link cmd} to access the CLI application
      * to interact from a shell with the Repository
      */
-    exports.cmd = require("./cliAnnotation/cmd").program;
+    exports.cmdAnnotation = require("./cliAnnotation/cmd").program;
 
     /**
      * @export CLI
@@ -44,7 +48,7 @@ if (typeof window === "undefined") {
      * @desc
      * Exports the [CLI utility class]{@link CLI} to initialize the API for CLI use
      */
-    exports.CLI = require("./cliAnnotation/core");
+    exports.CLIAnnotation = require("./cliAnnotation/core");
 
     /**
      * @export cmdTimeline
@@ -53,7 +57,7 @@ if (typeof window === "undefined") {
      * Exports the [Timeline CLI API client]{@link cmd} to access the CLI application
      * to interact from a shell with the Repository
      */
-    exports.cmd = require("./cliTimeline/cmd").program;
+    exports.cmdTimeline = require("./cliTimeline/cmd").program;
 
     /**
      * @export CLI
@@ -61,6 +65,6 @@ if (typeof window === "undefined") {
      * @desc
      * Exports the [CLI utility class]{@link CLI} to initialize the API for CLI use
      */
-    exports.CLI = require("./cliTimeline/core");
+    exports.CLITimeline = require("./cliTimeline/core");
 
 }


### PR DESCRIPTION
A bug had surfaced that had let this package override `--help` and other cli command params override any cli tool the package was integrated with.

The changes contained in this merge request prevent it from overriding `--help` in cases where the package is integrated in things like a grunt task for example. 

To facilitate this the creation of the initial commander program instance has been wrapped in a function and is only executed when the the actual cmd.js is called.

As well this merge request finalizes the migration to winston 3.x by revising how the `--json` flag is handled when parsing and validating options.